### PR TITLE
remove metrics dependency in order to use supplied transitive version

### DIFF
--- a/cwms-http-client/build.gradle
+++ b/cwms-http-client/build.gradle
@@ -23,24 +23,22 @@
  */
 
 plugins {
-    id 'java-library'
     id 'java-test-fixtures'
 }
 
 dependencies {
-    api(platform("com.squareup.okhttp3:okhttp-bom:4.9.2"))
-    api("com.squareup.okhttp3:okhttp:4.9.2")
-    api("com.squareup.okhttp3:logging-interceptor:4.9.2")
-    api('mil.army.usace.hec:metrics-services:2.0')
-    api('mil.army.usace.hec:lookup:1.0')
-    api('org.bouncycastle:bctls-jdk15on:1.63')
-    api('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0')
-    api('javax.annotation:javax.annotation-api:1.3.2')
-    api("com.auth0:java-jwt:4.0.0")
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.2"))
+    implementation("com.squareup.okhttp3:okhttp:4.9.2")
+    implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.9.2")
+    implementation('mil.army.usace.hec:metrics-services:2.0')
+    implementation('mil.army.usace.hec:lookup:1.0')
+    implementation('org.bouncycastle:bctls-jdk15on:1.63')
+    implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0')
+    implementation('javax.annotation:javax.annotation-api:1.3.2')
+    implementation("com.auth0:java-jwt:4.0.0")
 
     runtimeOnly('mil.army.usace.hec:metrics-codahale:2.0')
-    runtimeOnly('io.dropwizard.metrics:metrics-core:')
-
     annotationProcessor('mil.army.usace.hec:service-annotations:1.2.1')
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.8.1')


### PR DESCRIPTION
This fixes an issue where downstream maven projects failed to find ANY transitive dependencies because the single dependency's version wasn't supplied also set dependencies to implementation instead of api since we don't want to export these third-party libraries as compile-time