### PR TITLE
allow tsid patch to use a null new timeseries id

### DIFF
--- a/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/TimeSeriesIdentifierEndpointInput.java
+++ b/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/TimeSeriesIdentifierEndpointInput.java
@@ -49,8 +49,8 @@ public final class TimeSeriesIdentifierEndpointInput {
         return new Post(timeSeriesIdentifierDescriptor);
     }
 
-    public static Patch patch(String originalTimeSeriesId, String newTimeSeriesId, String officeId) {
-        return new Patch(originalTimeSeriesId, newTimeSeriesId, officeId);
+    public static Patch patch(String originalTimeSeriesId, String officeId) {
+        return new Patch(originalTimeSeriesId, officeId);
     }
 
     public static Delete delete(String timeSeriesId, String officeId) {
@@ -115,17 +115,20 @@ public final class TimeSeriesIdentifierEndpointInput {
         static final String OFFICE_QUERY_PARAMETER = "office";
         static final String INTERVAL_OFFSET_QUERY_PARAMETER = "interval-offset";
         private final String originalIdentifier;
-        private final String newIdentifier;
         private final String officeId;
+        private String newIdentifier;
         private Long intervalOffsetMinutes;
 
-        private Patch(String originalIdentifier, String newIdentifier, String officeId) {
+        private Patch(String originalIdentifier, String officeId) {
             this.originalIdentifier = Objects.requireNonNull(originalIdentifier,
                 "Cannot access the timeseries PATCH endpoint without an original time series identifier");
-            this.newIdentifier = Objects.requireNonNull(newIdentifier,
-                "Cannot access the timeseries PATCH endpoint without a new time series identifier");
             this.officeId = Objects.requireNonNull(officeId,
                 "Cannot access the timeseries PATCH endpoint without an office id");
+        }
+
+        public Patch newIdentifier(String newIdentifier) {
+            this.newIdentifier = newIdentifier;
+            return this;
         }
 
         public Patch intervalOffsetMinutes(long intervalOffsetMinutes) {

--- a/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestTimeSeriesIdentifierController.java
+++ b/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestTimeSeriesIdentifierController.java
@@ -101,7 +101,8 @@ class TestTimeSeriesIdentifierController extends TestController {
         TimeSeriesIdentifierController timeSeriesController = new TimeSeriesIdentifierController();
         timeSeriesController.storeTimeSeriesIdentifier(buildConnectionInfo(cookieJarSupplier), TimeSeriesIdentifierEndpointInput.post(timeSeries));
         TimeSeriesIdentifierEndpointInput.Patch input =
-            TimeSeriesIdentifierEndpointInput.patch(timeSeries.getTimeSeriesId(), timeSeries.getTimeSeriesId() + "-New", timeSeries.getOfficeId());
+            TimeSeriesIdentifierEndpointInput.patch(timeSeries.getTimeSeriesId(), timeSeries.getOfficeId())
+                .newIdentifier(timeSeries.getTimeSeriesId() + "-New");
         assertDoesNotThrow(() -> timeSeriesController.updateTimeSeriesIdentifier(buildConnectionInfo(cookieJarSupplier), input));
     }
 }

--- a/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestTimeSeriesIdentifierEndpointInput.java
+++ b/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestTimeSeriesIdentifierEndpointInput.java
@@ -134,12 +134,12 @@ class TestTimeSeriesIdentifierEndpointInput {
     @Test
     void testPatchQueryRequestDefaults() {
         MockHttpRequestBuilder mockHttpRequestBuilder = new MockHttpRequestBuilder();
-        TimeSeriesIdentifierEndpointInput.Patch input = TimeSeriesIdentifierEndpointInput.patch("arbu.Elev.Inst.1Hour.0.Ccp-Rev","arbu.Elev.Inst.1Hour.0.Ccp-Rev-new", "SWT");
+        TimeSeriesIdentifierEndpointInput.Patch input = TimeSeriesIdentifierEndpointInput.patch("arbu.Elev.Inst.1Hour.0.Ccp-Rev", "SWT");
         input.addInputParameters(mockHttpRequestBuilder);
         assertEquals("arbu.Elev.Inst.1Hour.0.Ccp-Rev", input.originalIdentifier());
         assertEquals("SWT", mockHttpRequestBuilder.getQueryParameter(OFFICE_QUERY_PARAMETER));
         assertNull(mockHttpRequestBuilder.getQueryParameter(INTERVAL_OFFSET_QUERY_PARAMETER));
-        assertEquals("arbu.Elev.Inst.1Hour.0.Ccp-Rev-new", mockHttpRequestBuilder.getQueryParameter(TIMESERIES_ID_QUERY_PARAMETER));
+        assertNull(mockHttpRequestBuilder.getQueryParameter(TIMESERIES_ID_QUERY_PARAMETER));
         assertEquals(ACCEPT_HEADER_V1, mockHttpRequestBuilder.getQueryHeader(ACCEPT_QUERY_HEADER));
     }
 
@@ -149,7 +149,8 @@ class TestTimeSeriesIdentifierEndpointInput {
         Instant start = ZonedDateTime.of(2018, 1, 5, 0, 0, 0, 0, ZoneId.of("UTC")).toInstant();
         Instant end = ZonedDateTime.of(2018, 2, 5, 0, 0, 0, 0, ZoneId.of("UTC")).toInstant();
         Instant now = Instant.now();
-        TimeSeriesIdentifierEndpointInput.Patch input = TimeSeriesIdentifierEndpointInput.patch("arbu.Elev.Inst.1Hour.0.Ccp-Rev","arbu.Elev.Inst.1Hour.0.Ccp-Rev-new", "SWT")
+        TimeSeriesIdentifierEndpointInput.Patch input = TimeSeriesIdentifierEndpointInput.patch("arbu.Elev.Inst.1Hour.0.Ccp-Rev", "SWT")
+            .newIdentifier("arbu.Elev.Inst.1Hour.0.Ccp-Rev-new")
             .intervalOffsetMinutes(500);
         input.addInputParameters(mockHttpRequestBuilder);
         assertEquals("arbu.Elev.Inst.1Hour.0.Ccp-Rev", input.originalIdentifier());
@@ -161,17 +162,12 @@ class TestTimeSeriesIdentifierEndpointInput {
 
     @Test
     void testPatchNullOriginalTimeSeriesId() {
-        assertThrows(NullPointerException.class, () -> TimeSeriesIdentifierEndpointInput.patch(null, null, null));
-    }
-
-    @Test
-    void testPatchNullNewTimeSeriesId() {
-        assertThrows(NullPointerException.class, () -> TimeSeriesIdentifierEndpointInput.patch("", null, null));
+        assertThrows(NullPointerException.class, () -> TimeSeriesIdentifierEndpointInput.patch(null, null));
     }
 
     @Test
     void testPatchNullOffice() {
-        assertThrows(NullPointerException.class, () -> TimeSeriesIdentifierEndpointInput.patch("", "", null));
+        assertThrows(NullPointerException.class, () -> TimeSeriesIdentifierEndpointInput.patch("", null));
     }
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'cwms-radar-client-parent'
+rootProject.name = 'CWMS Data API Client'
 
 include ":cwms-http-client"
 include ":cwms-radar-client"


### PR DESCRIPTION
this is used when not renaming, but updating the interval offset