### PR TITLE
remove synchronization on interceptors and authenticators

### DIFF
--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/OAuth2TokenInterceptor.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/OAuth2TokenInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,14 +24,15 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2Token;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2TokenProvider;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 final class OAuth2TokenInterceptor implements Interceptor {
 
@@ -45,7 +46,7 @@ final class OAuth2TokenInterceptor implements Interceptor {
     }
 
     @Override
-    public synchronized Response intercept(Chain chain) throws IOException {
+    public Response intercept(Chain chain) throws IOException {
         OAuth2Token oauth2Token = tokenProvider.getToken();
         if (oauth2Token == null) {
             throw new IOException("Authentication failed: No token retrieved from " + OAuth2TokenProvider.class.getName());

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/SimpleAuthHeaderAuthenticator.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/SimpleAuthHeaderAuthenticator.java
@@ -48,7 +48,7 @@ final class SimpleAuthHeaderAuthenticator implements Authenticator {
     }
 
     @Override
-    public synchronized Request authenticate(Route route, Response response) throws IOException {
+    public Request authenticate(Route route, Response response) throws IOException {
         LOGGER.log(Level.FINE, () -> "Authentication required for: " + response.request().url() + " attempting acquiring authorization key");
         String authorizationKey = keyProvider.getAuthorizationKey();
         if (authorizationKey == null) {

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/SimpleAuthHeaderInterceptor.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/SimpleAuthHeaderInterceptor.java
@@ -24,13 +24,14 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import mil.army.usace.hec.cwms.http.client.auth.SimpleAuthKeyProvider;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 final class SimpleAuthHeaderInterceptor implements Interceptor {
 
@@ -44,7 +45,7 @@ final class SimpleAuthHeaderInterceptor implements Interceptor {
     }
 
     @Override
-    public synchronized Response intercept(Chain chain) throws IOException {
+    public Response intercept(Chain chain) throws IOException {
         String authorizationKey = keyProvider.getAuthorizationKey();
         if (authorizationKey == null) {
             throw new IOException("Authentication failed: No authorization key retrieved from " + keyProvider.getClass().getName());


### PR DESCRIPTION
thread-safety should be handled by the wrapper providers otherwise all of the chain.proceeds will wind up blocking each other